### PR TITLE
FCREPO-3698 - Encoding of whitespace in filenames

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
       <artifactId>httpclient</artifactId>
       <version>${httpclient.version}</version>
     </dependency>
+    
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <version>${spring.version}</version>
+    </dependency>
 
     <!-- logging -->
     <dependency>

--- a/src/main/java/org/fcrepo/client/PostBuilder.java
+++ b/src/main/java/org/fcrepo/client/PostBuilder.java
@@ -19,14 +19,14 @@ package org.fcrepo.client;
 
 import static org.fcrepo.client.FedoraHeaderConstants.CONTENT_DISPOSITION;
 import static org.fcrepo.client.FedoraHeaderConstants.SLUG;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
-import java.net.URLEncoder;
 
 import org.apache.http.client.methods.HttpRequestBase;
+import org.springframework.http.ContentDisposition;
 
 /**
  * Builds a post request for interacting with the Fedora HTTP API in order to create a new resource within an LDP
@@ -125,12 +125,10 @@ public class PostBuilder extends BodyRequestBuilder {
      * @throws FcrepoOperationFailedException if unable to encode filename
      */
     public PostBuilder filename(final String filename) throws FcrepoOperationFailedException {
-        try {
-            final String f = (filename != null) ? "; filename=\"" + URLEncoder.encode(filename, "utf-8") + "\"" : "";
-            request.addHeader(CONTENT_DISPOSITION, "attachment" + f);
-        } catch (final UnsupportedEncodingException e) {
-            throw new FcrepoOperationFailedException(request.getURI(), -1, e.getMessage());
-        }
+        final ContentDisposition contentDisposition = ContentDisposition.builder("attachment")
+                .filename(filename)
+                .build();
+        request.addHeader(CONTENT_DISPOSITION, contentDisposition.toString());
         return this;
     }
 

--- a/src/main/java/org/fcrepo/client/PutBuilder.java
+++ b/src/main/java/org/fcrepo/client/PutBuilder.java
@@ -23,11 +23,10 @@ import static org.fcrepo.client.FedoraHeaderConstants.PREFER;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
-import java.net.URLEncoder;
 
 import org.apache.http.client.methods.HttpRequestBase;
+import org.springframework.http.ContentDisposition;
 
 /**
  * Builds a PUT request for interacting with the Fedora HTTP API in order to create a resource with a specified path,
@@ -141,12 +140,10 @@ public class PutBuilder extends BodyRequestBuilder {
      * @throws FcrepoOperationFailedException if unable to encode filename
      */
     public PutBuilder filename(final String filename) throws FcrepoOperationFailedException {
-        try {
-            final String f = (filename != null) ? "; filename=\"" + URLEncoder.encode(filename, "utf-8") + "\"" : "";
-            request.addHeader(CONTENT_DISPOSITION, "attachment" + f);
-        } catch (final UnsupportedEncodingException e) {
-            throw new FcrepoOperationFailedException(request.getURI(), -1, e.getMessage());
-        }
+        final ContentDisposition contentDisposition = ContentDisposition.builder("attachment")
+                .filename(filename)
+                .build();
+        request.addHeader(CONTENT_DISPOSITION, contentDisposition.toString());
         return this;
     }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3698

# What does this Pull Request do?
* Change encoding of filename Content-disposition field to resolve space encoding issues. 
* Adds dependency on spring-web in order to have access to ContentDisposition utility.

# Notes
UTF-8 is NOT supported by the client in filenames at this point, and possibly not by Fedora. The utility used for encoding the filename does support UTF-8, but it will need to be addressed in Fedora first. See https://jira.lyrasis.org/browse/FCREPO-3700

# How should this be tested?
See the ticket for example. There are also new integration tests.
