### PR TITLE
Avoid setting filename when null

### DIFF
--- a/src/main/java/org/fcrepo/client/PostBuilder.java
+++ b/src/main/java/org/fcrepo/client/PostBuilder.java
@@ -27,6 +27,7 @@ import java.net.URI;
 
 import org.apache.http.client.methods.HttpRequestBase;
 import org.springframework.http.ContentDisposition;
+import org.springframework.http.ContentDisposition.Builder;
 
 /**
  * Builds a post request for interacting with the Fedora HTTP API in order to create a new resource within an LDP
@@ -125,10 +126,11 @@ public class PostBuilder extends BodyRequestBuilder {
      * @throws FcrepoOperationFailedException if unable to encode filename
      */
     public PostBuilder filename(final String filename) throws FcrepoOperationFailedException {
-        final ContentDisposition contentDisposition = ContentDisposition.builder("attachment")
-                .filename(filename)
-                .build();
-        request.addHeader(CONTENT_DISPOSITION, contentDisposition.toString());
+        final Builder builder = ContentDisposition.builder("attachment");
+        if (filename != null) {
+            builder.filename(filename);
+        }
+        request.addHeader(CONTENT_DISPOSITION, builder.build().toString());
         return this;
     }
 

--- a/src/main/java/org/fcrepo/client/PutBuilder.java
+++ b/src/main/java/org/fcrepo/client/PutBuilder.java
@@ -27,6 +27,7 @@ import java.net.URI;
 
 import org.apache.http.client.methods.HttpRequestBase;
 import org.springframework.http.ContentDisposition;
+import org.springframework.http.ContentDisposition.Builder;
 
 /**
  * Builds a PUT request for interacting with the Fedora HTTP API in order to create a resource with a specified path,
@@ -140,10 +141,11 @@ public class PutBuilder extends BodyRequestBuilder {
      * @throws FcrepoOperationFailedException if unable to encode filename
      */
     public PutBuilder filename(final String filename) throws FcrepoOperationFailedException {
-        final ContentDisposition contentDisposition = ContentDisposition.builder("attachment")
-                .filename(filename)
-                .build();
-        request.addHeader(CONTENT_DISPOSITION, contentDisposition.toString());
+        final Builder builder = ContentDisposition.builder("attachment");
+        if (filename != null) {
+            builder.filename(filename);
+        }
+        request.addHeader(CONTENT_DISPOSITION, builder.build().toString());
         return this;
     }
 

--- a/src/test/java/org/fcrepo/client/integration/FcrepoClientIT.java
+++ b/src/test/java/org/fcrepo/client/integration/FcrepoClientIT.java
@@ -208,6 +208,18 @@ public class FcrepoClientIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testPostBinaryNullFilename() throws Exception {
+        final String bodyContent = "Hello world";
+
+        final FcrepoResponse response = client.post(new URI(serverAddress))
+                .body(new ByteArrayInputStream(bodyContent.getBytes()), "text/plain")
+                .filename(null)
+                .perform();
+
+        assertEquals("Empty filename rejected", CREATED.getStatusCode(), response.getStatusCode());
+    }
+
+    @Test
     public void testPostDirectContainer() throws Exception {
         final FcrepoResponse response = client.post(new URI(serverAddress))
                 .addInteractionModel(LDP_DIRECT_CONTAINER)
@@ -396,6 +408,18 @@ public class FcrepoClientIT extends AbstractResourceIT {
 
         final String getContent = IOUtils.toString(getResponse.getBody(), "UTF-8");
         assertEquals(fileContent, getContent);
+    }
+
+    @Test
+    public void testPutBinaryNullFilename() throws Exception {
+        final String bodyContent = "Hello world";
+
+        final FcrepoResponse response = client.put(url)
+                .body(new ByteArrayInputStream(bodyContent.getBytes()), "text/plain")
+                .filename(null)
+                .perform();
+
+        assertEquals("Empty filename rejected", CREATED.getStatusCode(), response.getStatusCode());
     }
 
     @Test


### PR DESCRIPTION
Avoid setting filename when provided null, as this will throw an IllegalArgumentException in later 5.x versions of spring-web
* This was introduced in spring-web 5.2.3 in this change: https://github.com/spring-projects/spring-framework/commit/41f40c6c229d3b4f768718f1ec229d8f0ad76d76#diff-bc6f2be3194d27e834cae36ac471f18971e3bd65b49163634d3c1daeb1943a8eR546