### PR TITLE
updating actions/cache github action as v2 is being deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         java-version: 11 
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
**updating actions/cache github action as v2 is being deprecated **
* * *

**JIRA Ticket**: https://github.com/actions/toolkit/tree/main/packages/cache

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
bumps actions/cache from v2 to v4 

# How should this be tested?
Check GH Actions still run as expected. The action is supposedly backwards compatible so no issues are expected



# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.


# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
